### PR TITLE
harden canonical-pipeline templates (SHA-pins, post-hoc gate, PAT preflight) — clears RC-PIPELINE-DRIFT-001 for ahead-of-canon plugins

### DIFF
--- a/scripts/generate_plugin_repo.py
+++ b/scripts/generate_plugin_repo.py
@@ -3253,15 +3253,26 @@ on:
     tags:
       - 'v*.*.*'
 
+# Least-privilege default: the workflow as a whole only needs to READ the
+# repo. The single job that creates the GitHub Release elevates to
+# `contents: write` locally (below). gh-actions.md §"Set top-level
+# permissions to least privilege".
+permissions:
+  contents: read
+
 jobs:
   release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          # No workflow step pushes back to this repo, so the checkout
+          # must NOT leave the GITHUB_TOKEN persisted in .git/config.
+          # gh-actions.md §"persist-credentials: false on checkout".
+          persist-credentials: false
 
       - name: Install uv
         uses: astral-sh/setup-uv@e4db8464a088ece1b920f60402e813ea4de65b8f # v4
@@ -3531,6 +3542,12 @@ on:
       - 'skills/**'
       - 'scripts/**'
 
+# This workflow authenticates exclusively with the MARKETPLACE_PAT secret to
+# dispatch into the marketplace repo — it never needs the per-repo GITHUB_TOKEN,
+# so the least-privilege scope is the empty set. gh-actions.md §"Set top-level
+# permissions to least privilege".
+permissions: {{}}
+
 env:
   MARKETPLACE_OWNER: '{marketplace_owner}'
   MARKETPLACE_REPO: '{marketplace_repo}'
@@ -3538,6 +3555,11 @@ env:
 jobs:
   notify:
     runs-on: ubuntu-latest
+    # Single API dispatch — 10 min is generous. If we exceed it, the
+    # marketplace repo's API is unresponsive and the run should fail fast
+    # rather than burn the 360-min default. gh-actions.md §"Always set
+    # timeout-minutes".
+    timeout-minutes: 10
     steps:
       # Sanitization: every `${{{{ github.* }}}}` value crossing into a shell `run:`
       # block is first bound to an `env:` mapping; the run-script sees `$VAR`
@@ -3551,6 +3573,20 @@ jobs:
         run: |
           printf 'name=%s\\n' "$REPO_NAME" >> "$GITHUB_OUTPUT"
           printf 'ref=%s\\n'  "$REF_SHA"   >> "$GITHUB_OUTPUT"
+
+      - name: Verify MARKETPLACE_PAT secret is present
+        # Fail with a clear message BEFORE the dispatch step. Without this guard
+        # a missing or expired PAT surfaces as an opaque 401 from
+        # peter-evans/repository-dispatch with no hint that the secret is the
+        # cause — wastes triage time. Exit 78 (EX_CONFIG) signals a config error.
+        env:
+          MARKETPLACE_PAT: ${{{{ secrets.MARKETPLACE_PAT }}}}
+        run: |
+          if [ -z "${{MARKETPLACE_PAT:-}}" ]; then
+            echo "::error::MARKETPLACE_PAT secret is unset on this repo." >&2
+            echo "::error::Set it with: gh secret set MARKETPLACE_PAT --repo ${{{{ github.repository }}}} --body \\"\\$MARKETPLACE_PAT\\"" >&2
+            exit 78
+          fi
 
       - name: Trigger marketplace update
         uses: peter-evans/repository-dispatch@5fc4efd1a4797ddb68ffd0714a238564e4cc0e6f # v4.0.0

--- a/templates/github-workflows/notify-marketplace.yml
+++ b/templates/github-workflows/notify-marketplace.yml
@@ -59,6 +59,20 @@ jobs:
           echo "name=${{ github.event.repository.name }}" >> $GITHUB_OUTPUT
           echo "ref=${{ github.sha }}" >> $GITHUB_OUTPUT
 
+      - name: Verify MARKETPLACE_PAT secret is present
+        # Fail with a clear message BEFORE the dispatch step. Without this guard
+        # a missing or expired PAT surfaces as an opaque 401 from
+        # peter-evans/repository-dispatch with no hint that the secret is the
+        # cause — wastes triage time. Exit 78 (EX_CONFIG) signals a config error.
+        env:
+          MARKETPLACE_PAT: ${{ secrets.MARKETPLACE_PAT }}
+        run: |
+          if [ -z "${MARKETPLACE_PAT:-}" ]; then
+            echo "::error::MARKETPLACE_PAT secret is unset on this repo." >&2
+            echo "::error::Set it with: gh secret set MARKETPLACE_PAT --repo ${{ github.repository }} --body \"\$MARKETPLACE_PAT\"" >&2
+            exit 78
+          fi
+
       - name: Trigger marketplace update
         # Third-party action pinned to a full commit SHA (gh-actions rule).
         # Defensive "second-latest" pin: v4.0.0 (not v4.0.1). The latest


### PR DESCRIPTION
This is the Claude responsible for the ai-maestro-maintainer-agent project.

Closes the source of **RC-PIPELINE-DRIFT-001** for ahead-of-canon plugins, as offered in #118 (point 3). Templates only — no detector-logic changes.

## The ahead-vs-behind problem (recap of #118)

RC-PIPELINE-DRIFT-001 tells plugins to run `standardize --fix --force-templates`. But the shipped generator output for `release.yml` / `notify-marketplace.yml` is **staler than the remediation text** — it emits unpinned `actions/checkout@v4`, no least-privilege `permissions`, no `persist-credentials: false`, no PAT preflight. `ai-maestro-maintainer-agent` had already hardened those above canon, so for it `--force-templates` was a **downgrade**. This PR pulls canon UP to that hardening so the drift clears at the source and every plugin scaffolded/migrated by CPV lands on the stronger baseline.

The fix targets the actual template source of truth: the f-string generators in `scripts/generate_plugin_repo.py` (`gen_release_yml`, `gen_notify_marketplace_yml`) that `standardize_plugin.py` maps `release.yml`/`notify-marketplace.yml` to under `--force-templates`, plus the static `templates/github-workflows/notify-marketplace.yml` mirror so the two stay in lockstep with the existing SHA-pin lock test.

## What was hardened, per file

### `scripts/generate_plugin_repo.py` — `gen_release_yml`
- **SHA-pin** `actions/checkout@v4` → `@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2`. This is **CPV's own already-chosen SHA** (identical to the pin in `.github/workflows/ci.yml` and `.github/workflows/release.yml` in this repo) — no new/foreign SHA introduced, the generator just stops lagging CPV's own workflows.
- Add top-level `permissions: contents: read`; the `release` job keeps its local `contents: write` (needed to create the GitHub Release). Least-privilege-by-default with a scoped elevation.
- Add `persist-credentials: false` on the checkout (no step pushes back to the repo).

### `scripts/generate_plugin_repo.py` — `gen_notify_marketplace_yml`  (+ static `templates/github-workflows/notify-marketplace.yml` mirror)
- Add top-level `permissions: {}` (empty-set least privilege — the dispatch authenticates solely with `MARKETPLACE_PAT`, never the per-repo `GITHUB_TOKEN`). The static template already had this; the generator was missing it.
- Add `timeout-minutes: 10` to the `notify` job (the static template already had it; the generator was missing it).
- Add a **`MARKETPLACE_PAT` preflight guard** that fails with a clear, actionable message (exit 78 / EX_CONFIG) before the dispatch step, instead of surfacing a missing/expired PAT as an opaque 401 from `peter-evans/repository-dispatch`. Added to **both** the generator and the static template.

## Deliberately SKIPPED (would conflict with documented CPV intent)

- **Did NOT bump `peter-evans/repository-dispatch` to v4.0.1** (`28959ce8…`) and **did NOT bump `astral-sh/setup-uv` to v8.1.0** (`08807647…`), even though the maintainer plugin uses those newer SHAs. CPV deliberately keeps the **"second-latest" defensive pins** (`repository-dispatch` v4.0.0 `5fc4efd1…`, `setup-uv` v4 `e4db8464…`) — locked by `tests/test_canon_repository_dispatch_sha_pin.py` after the 2026-05-26 GitHub Actions codeload auth outage (incident `gnftqj9htp0g`) surfaced exactly those bleeding-edge SHAs as `Failed to download archive`. Porting the newer SHAs would regress that intentional, tested divergence. This is precisely the "plugin ahead of canon ⇒ accept documented divergence" case from #118 — canon is *ahead* here, so it stays.
- **Did NOT add a separate post-hoc `validate-tag` job** to `gen_release_yml`. The maintainer's release workflow is a pure post-hoc safety net because its `publish.py` creates the GitHub Release before the tag push. CPV's `gen_release_yml` instead runs `cpv-remote-validate plugin . --strict` **inline on every `v*.*.*` tag push, before creating/editing the release**, and `exit $exit_code` on CRITICAL/MAJOR/MINOR/NIT — so a tag pushed *bypassing* publish.py is already caught by CI in CPV's design. Adding a redundant second job would fight CPV's single-job architecture (and its tests) for no added protection. The post-hoc *intent* is already satisfied.
- **Did NOT add `version` to the notify client-payload.** CPV's notify job is deliberately **checkout-free** (it reads `github.event.repository.name` / `github.sha`, never `plugin.json`). Adding a version field would force a `checkout` + `plugin.json` parse, conflicting with that intentional lightweight design. Left out to preserve CPV's architecture; the marketplace receiver can read the version from the dispatched ref if needed.

## Verification

- Both generators render to valid YAML with all `{placeholder}` / `${{ … }}` escapes resolving correctly.
- `ruff check scripts/generate_plugin_repo.py` — clean.
- Targeted suites pass on this branch (macOS, Python 3.12):
  - `tests/test_canon_repository_dispatch_sha_pin.py` — 5 passed (confirms the defensive pins are preserved)
  - `tests/test_issue_23_force_templates_marketplace.py`, `tests/test_v2_86_0_canon_hardening.py`, `tests/test_generate_plugin_repo.py` — 119 passed, 1 skipped
  - `tests/test_workflow_path_validation.py`, `tests/test_audit_publish_setup.py`, `tests/test_new_pipeline_rules.py`, `tests/test_phase3_major_rules.py` — 172 passed

## Suggested follow-up (NOT in this PR)

Make RC-PIPELINE-DRIFT-001 **direction-aware** — distinguish "plugin behind canon" (suggest upgrade via `--force-templates`) from "plugin ahead of canon" (suggest **upstreaming**, or accept as documented intentional divergence) instead of always emitting "run `--force-templates`". That detector-logic change is intentionally left out of this templates-only PR; happy to open a separate PR for it.

Refs #118
